### PR TITLE
fix: provider dropdown is empty on upload page

### DIFF
--- a/components/UploadCSV/FileUpload.tsx
+++ b/components/UploadCSV/FileUpload.tsx
@@ -131,6 +131,8 @@ const FileUpload: FC = () => {
     },
   });
 
+  if (!tenants?.length) return null;
+
   return (
     <div className="w-full flex flex-col gap-8 mt-4">
       <div className="w-full flex flex-col gap-2">


### PR DESCRIPTION
BUG: Provider dropdown is empty on the upload csv page

<img width="873" alt="Screenshot 2024-10-30 at 16 29 38" src="https://github.com/user-attachments/assets/a101546e-5210-4823-ae5c-4f86f144c832">
