### PR TITLE
fix: proper error handling for signup form

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   title: 'ProxyLink | Sign Up',
 };
 
+export type SignUpResponse = {
+  user: User | null;
+  error?: string;
+};
+
 export default async function SignUpPage({
   searchParams,
 }: {
@@ -22,10 +27,10 @@ export default async function SignUpPage({
   console.log('newUserData', newUserData);
 
   // Server Action to handle sign-up
-  const handleSignUp = async (formData: FormData): Promise<User | null> => {
+  const handleSignUp = async (formData: FormData): Promise<SignUpResponse> => {
     'use server';
     if (!newUserData || newUserData === 'expired') {
-      return null;
+      return { user: null, error: 'Invalid or expired invitation' };
     }
     try {
       const firstName = formData.get('firstName') as string;
@@ -78,10 +83,13 @@ export default async function SignUpPage({
         await invitationDoc.ref.delete();
       }
 
-      return newUser;
+      return { user: newUser };
     } catch (error) {
       console.error(parseErrorMessage(error));
-      throw new Error('Sign-up failed: ' + parseErrorMessage(error));
+      return {
+        user: null,
+        error: parseErrorMessage(error),
+      };
     }
   };
 

--- a/components/Login/Login.tsx
+++ b/components/Login/Login.tsx
@@ -9,12 +9,12 @@ import { Button } from '@headlessui/react';
 import Footer from '@/app/(public)/components/Footer';
 import SignUpForm from './SignUpForm';
 import { NewUserData } from '@/lib/jwt/utils';
-import { User } from '@/lib/db/schema';
+import { SignUpResponse } from '@/app/(auth)/signup/page';
 
 type Props = {
   type?: 'reset-password' | 'sign-up';
   newUserData?: NewUserData | null | 'expired';
-  handleSignUp?: (formData: FormData) => Promise<User | null>;
+  handleSignUp?: (formData: FormData) => Promise<SignUpResponse>;
 };
 
 const Login: FC<Props> = ({ type, newUserData, handleSignUp }) => {

--- a/components/Login/SignUpForm.tsx
+++ b/components/Login/SignUpForm.tsx
@@ -3,12 +3,11 @@
 import { Button } from '@/components/ui/button';
 import { FormEvent, useState } from 'react';
 import { NewUserData } from '@/lib/jwt/utils';
-import { parseErrorMessage } from '@/utils/general';
-import { User } from '@/lib/db/schema';
 import {
   IoMdCheckmarkCircleOutline,
   IoMdCloseCircleOutline,
 } from 'react-icons/io';
+import { SignUpResponse } from '@/app/(auth)/signup/page';
 
 const SignUpTokenError = () => {
   return (
@@ -44,10 +43,10 @@ const SucessMessage = () => (
 
 type Props = {
   newUserData: NewUserData | null | 'expired' | undefined;
-  handleSignUp: (formData: FormData) => Promise<User | null>;
+  handleSignUp: (formData: FormData) => Promise<SignUpResponse>;
 };
 
-const LoginForm: React.FC<Props> = ({
+const SignUpForm: React.FC<Props> = ({
   newUserData = 'expired',
   handleSignUp,
 }) => {
@@ -66,13 +65,15 @@ const LoginForm: React.FC<Props> = ({
     const formData = new FormData(e.currentTarget);
 
     try {
-      const user = await handleSignUp(formData);
-      if (user) {
+      const response = await handleSignUp(formData);
+      if (response.error) {
+        setError(response.error);
+      } else if (response.user) {
         setError('');
         setSuccessMsg(true);
       }
     } catch (err) {
-      setError(parseErrorMessage(err));
+      setError('An unexpected error occurred');
     } finally {
       setLoading(false);
     }
@@ -211,4 +212,4 @@ const LoginForm: React.FC<Props> = ({
   );
 };
 
-export default LoginForm;
+export default SignUpForm;


### PR DESCRIPTION
# PR Title
`fix: Proper error handling for signup form in production`

# Description
```
## Problem
When users attempt to sign up with an existing email address in production, they see a generic Next.js error message: "An error occurred in the Server Components render..." instead of the actual error message. This happens because the server action is throwing raw errors which Next.js sanitizes in production for security reasons.

## Solution
Modified the server action to return structured error responses instead of throwing errors. This ensures that error messages are properly serialized and safely passed to the client, while maintaining detailed error information.

## Changes
- Updated `handleSignUp` server action to return structured `SignUpResponse` type
- Ensured error messages are properly propagated to the client
- Maintained error logging on the server side for debugging
- No changes to the underlying signup logic or security measures

## Testing
- [ ] Verify error message shows correctly when signing up with existing email
- [ ] Verify successful signup still works as expected
- [ ] Test in development and production environments
```